### PR TITLE
Two updates to how test results are passed to SBT.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@ object TestNGPluginBuild extends Build {
   lazy val root = Project(id = "sbt-testng-interface", base = file("."))
     .settings(commonSettings: _*)
     .settings(
-      version := "3.0.2",
+      version := "3.0.3",
       crossScalaVersions := Seq("2.9.3", "2.10.4", "2.11.2"),
       libraryDependencies ++= Seq(
         "org.scala-sbt" % "test-interface" % "1.0" % "provided",
@@ -18,7 +18,7 @@ object TestNGPluginBuild extends Build {
     .settings(commonSettings: _*)
     .settings(
       sbtPlugin := true,
-      version := "3.0.2",
+      version := "3.0.3",
       crossScalaVersions := Seq("2.10.4"),
       scalacOptions += "-language:_")
 

--- a/src/main/scala/de/johoop/testnginterface/EventRecorder.scala
+++ b/src/main/scala/de/johoop/testnginterface/EventRecorder.scala
@@ -33,10 +33,6 @@ import collection.mutable.HashMap
 import org.scalatools.testing.EventHandler
 import org.scalatools.testing.Logger
 import ResultEvent._
-import org.scalatools.testing.Result
-import org.scalatools.testing.Fingerprint
-import org.scalatools.testing.SubclassFingerprint
-import org.testng.ITestContext
 
 class EventRecorder extends TestListenerAdapter {
   private[this] val basket = HashMap[String, List[Event]]()

--- a/src/main/scala/de/johoop/testnginterface/ResultEvent.scala
+++ b/src/main/scala/de/johoop/testnginterface/ResultEvent.scala
@@ -31,7 +31,7 @@ import org.scalatools.testing.Result
 import Result._
 import org.testng.ITestResult
 
-case class ResultEvent(val result: Result, val testName: String, val description: String, val error: Throwable) extends Event
+case class ResultEvent(result: Result, testName: String, description: String, error: Throwable) extends Event
 
 object ResultEvent {
   val failure = (result: ITestResult) => event(Failure, result)
@@ -39,7 +39,8 @@ object ResultEvent {
   val success = (result: ITestResult) => event(Success, result)
   
   private[this] def event(result: Result, testNGResult: ITestResult) = 
-    ResultEvent(result, classNameOf(testNGResult), testNGResult getName, testNGResult getThrowable)
+    ResultEvent(result, testNGResult.getName, testNGResult.getName,
+        if (result != Success) testNGResult.getThrowable else null)
     
   def classNameOf(result: ITestResult) = result.getTestClass.getName
 }

--- a/src/main/scala/de/johoop/testnginterface/TestNGRunner.scala
+++ b/src/main/scala/de/johoop/testnginterface/TestNGRunner.scala
@@ -27,12 +27,10 @@
 package de.johoop.testnginterface
 
 import org.scalatools.testing.Fingerprint
-import org.scalatools.testing.Framework
 import org.scalatools.testing.Logger
 import org.scalatools.testing.Runner2
 import org.scalatools.testing.EventHandler
 import TestNGInstance.start
-import java.util.concurrent.atomic.AtomicInteger
 
 class TestNGRunner(testClassLoader: ClassLoader, loggers: Array[Logger], state: TestRunState) extends Runner2 {
   import state._
@@ -40,16 +38,16 @@ class TestNGRunner(testClassLoader: ClassLoader, loggers: Array[Logger], state: 
   def run(testClassname: String, fingerprint: Fingerprint, eventHandler: EventHandler, testOptions: Array[String]) = {
     loggers foreach (_.debug("running for " + testClassname))
     
-    if (permissionToExecute tryAcquire) {
+    if (permissionToExecute.tryAcquire) {
       start(TestNGInstance loggingTo loggers
                            loadingClassesFrom testClassLoader 
                            using testOptions 
                            storingEventsIn recorder)
                            
-      testCompletion countDown
+      testCompletion.countDown()
     }
                            
-    testCompletion await
+    testCompletion.await()
     
     recorder.replayTo(eventHandler, testClassname, loggers)
   }


### PR DESCRIPTION
First, record the name of the test method as the test name instead of the name of the
test class. The test name is much more useful in the output than the test class.

Second, we will no longer pass the Throwable from TestNG's ITestResult if the test
succeeded. It's possible for a successful test to have a non-null Throwable, if for
example the test annotation specifies an expectedExceptions parameter. This change
stops printing those exceptions as errors.