### PR TITLE
Use correct URL for sbt-plugin-releases repository:

### DIFF
--- a/plugin/src/main/scala/de/johoop/testngplugin/TestNGPlugin.scala
+++ b/plugin/src/main/scala/de/johoop/testngplugin/TestNGPlugin.scala
@@ -30,8 +30,7 @@ import sbt.Keys._
 
 object TestNGPlugin extends Plugin with Keys {
   def testNGSettings: Seq[Setting[_]] = Seq(
-	resolvers += Resolver.url("scala-sbt simple releases", 
-		url("http://repo.scala-sbt.org/scalasbt/simple/sbt-plugin-releases"))(Resolver.ivyStylePatterns), // why is that necessary, and why like that?
+	resolvers += Resolver.sbtPluginRepo("releases"), // why is that necessary, and why like that?
 
     testNGVersion := "6.8.8",
     testNGOutputDirectory := (crossTarget.value / "testng").absolutePath,


### PR DESCRIPTION
The old URL has an extra path element “simple/“. This does not
work anymore after the July 2015 migration of repo-scala-sbt.org
to Artifactory and breaks builds on Travis CI. Switching to the
standard URL provided directly by sbt should fix this problem.